### PR TITLE
Fix 2025 paths

### DIFF
--- a/src/main/kotlin/org/rowlandhall/meepmeep/MeepMeep.kt
+++ b/src/main/kotlin/org/rowlandhall/meepmeep/MeepMeep.kt
@@ -507,13 +507,13 @@ constructor(private val windowX: Int, private val windowY: Int, private val fps:
                                     "background/season-2024-intothedeep/field-2024-juice-black.png"
 
                                 Background.FIELD_DECODE_JUICE_DARK ->
-                                    "background/season-2025-decode/field-2024-juice-dark.png"
+                                    "background/season-2025-decode/field-2025-juice-dark.png"
 
                                 Background.FIELD_DECODE_JUICE_LIGHT ->
-                                    "background/season-2025-decode/field-2024-juice-light.png"
+                                    "background/season-2025-decode/field-2025-juice-light.png"
 
                                 Background.FIELD_DECODE_OFFICIAL ->
-                                    "background/season-2025-decode/field-2024-official.png"
+                                    "background/season-2025-decode/field-2025-official.png"
                             }
 
                     val isDarkMode = path.contains("dark", ignoreCase = true)


### PR DESCRIPTION
The paths in the Kotlin files are wrong for the new Decode fields, resulting in

```
Exception in thread "main" java.lang.IllegalArgumentException: input == null!
	at java.desktop/javax.imageio.ImageIO.read(Unknown Source)
	at org.rowlandhall.meepmeep.MeepMeep.setBackground(MeepMeep.kt:527)
	at com.example.meepmeeptesting.MeepMeepTesting.main(MeepMeepTesting.java:28)
```

when trying to use them. This PR just updates the paths to match what's actually in `resources/background`.